### PR TITLE
Implementation of OneDirectoryLinkPathRecover

### DIFF
--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/OneDirectoryLinkPathRecover.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/OneDirectoryLinkPathRecover.java
@@ -1,0 +1,48 @@
+package org.bandrsoftwares.cipherbox.fuse.nio;
+
+import lombok.Getter;
+import lombok.NonNull;
+
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.nio.file.Path;
+
+/**
+ * Implementation of {@link PhysicalPathRecover} which is link to only ONE physical directory. This directory will be the root of the File System and
+ * all manipulated files will be in it.
+ * <p>
+ * The method {@link #recover(Path)} only call {@link Path#resolve(Path)} to create the physical path of a fuse path.
+ */
+@Getter
+public class OneDirectoryLinkPathRecover implements PhysicalPathRecover {
+
+    // Variables.
+
+    @NonNull
+    private final Path rootDirectory;
+
+    // Constructors.
+
+    @Inject
+    OneDirectoryLinkPathRecover(@RootDirectory @NonNull Path rootDirectory) {
+        this.rootDirectory = rootDirectory;
+    }
+
+    // Methods.
+
+    @Override
+    public Path recover(@NonNull Path fusePath) {
+        return rootDirectory.resolve(fusePath);
+    }
+
+    // Inner classes.
+
+    @Documented
+    @Qualifier
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface RootDirectory {
+    }
+}


### PR DESCRIPTION
OneDirectoryLinkPathRecover is an implementation of PhysicalPathRecover.

OneDirectoryLinkPathRecover is link to only ONE
directory and use Path.resolve(Path) to recover
a physical path of a fuse path.

It as an @Inject constructor which take in parameter a @RootDirectory which is the physical path of the root directory.