### PR TITLE
Create runnable examples and fix bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,20 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>19</maven.compiler.source>
-        <maven.compiler.target>19</maven.compiler.target>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>16</source>
+                    <target>16</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- jnr-fuse -->

--- a/src/main/java/org/bandrsoftwares/cipherbox/example/nio/NIOExampleMain.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/example/nio/NIOExampleMain.java
@@ -1,0 +1,38 @@
+package org.bandrsoftwares.cipherbox.example.nio;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import lombok.extern.slf4j.Slf4j;
+import org.bandrsoftwares.cipherbox.fuse.ConcreteFuseFS;
+import ru.serce.jnrfuse.FuseStubFS;
+
+import java.nio.file.Paths;
+import java.util.Scanner;
+
+@Slf4j
+public class NIOExampleMain {
+
+    public static void main(String[] args) {
+        try {
+            ConcreteFuseFS nioFuseFS;
+            Injector injector = Guice.createInjector(new NIOGuiceModule());
+            nioFuseFS = injector.getInstance(ConcreteFuseFS.class);
+
+            log.info("Mount NIO Fuse FS");
+            nioFuseFS.mount(Paths.get("R:\\"), false, false);
+            waitEnd(nioFuseFS);
+
+            log.info("Unmount NIO Fuse FS");
+        } catch (Throwable e) {
+            log.error("Fail during process", e);
+        }
+    }
+
+    public static void waitEnd(FuseStubFS fuseFS) {
+        Scanner sc = new Scanner(System.in);
+        while (!(sc.next()).equals("q")) {
+            // Nothing to do
+        }
+        fuseFS.umount();
+    }
+}

--- a/src/main/java/org/bandrsoftwares/cipherbox/example/nio/NIOGuiceModule.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/example/nio/NIOGuiceModule.java
@@ -1,0 +1,47 @@
+package org.bandrsoftwares.cipherbox.example.nio;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import org.bandrsoftwares.cipherbox.fuse.*;
+import org.bandrsoftwares.cipherbox.fuse.nio.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class NIOGuiceModule extends AbstractModule {
+
+    // Methods.
+
+    @Override
+    protected void configure() {
+        bind(ConcreteFuseFS.class);
+
+        bind(FuseLockManager.class).to(BasicFuseLockManager.class);
+
+        bind(FileAttributesUtil.class);
+
+        bind(PhysicalPathRecover.class).to(OneDirectoryLinkPathRecover.class);
+
+        bind(FileReferenceGenerator.class).to(BasicFileReferenceGenerator.class);
+        bind(FileReferenceFactory.class).to(BasicFileReferenceFactory.class);
+        bind(FuseFileManager.class).to(NIOFuseFileManager.class);
+
+        bind(FuseDirectoryManager.class).to(NIOFuseDirectoryManager.class);
+
+        bind(FuseLinkManager.class).to(NIOFuseLinkManager.class);
+
+        bind(FuseFSActionManager.class).to(NIOFuseFSActionManager.class);
+    }
+
+    @Provides
+    @OneDirectoryLinkPathRecover.RootDirectory
+    public Path provideRootDirectory() {
+        return Paths.get("C:\\Users\\YOUR_DIRECTORY");
+    }
+
+    @Provides
+    @BasicFileReferenceGenerator.BufferSize
+    public Integer provideBufferSize() {
+        return 8192;
+    }
+}

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/BasicFuseLockManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/BasicFuseLockManager.java
@@ -26,6 +26,8 @@ public class BasicFuseLockManager implements FuseLockManager {
 
     private final LoadingCache<Path, PathLock> cache = CacheBuilder.newBuilder().build(lockLoader);
 
+    private ConcreteFuseFS fuseFS;
+
     // Constructors.
 
     @Inject
@@ -43,6 +45,17 @@ public class BasicFuseLockManager implements FuseLockManager {
             log.error("Fail to get lock in cache for the path " + path, e);
             throw new FailLoadingPathLockException(e);
         }
+    }
+
+    @Override
+    public ConcreteFuseFS getFuseFS() {
+        return fuseFS;
+    }
+
+    @Override
+    public void init(@NonNull ConcreteFuseFS fuseFS) {
+        if (!hasBeenInitialized())
+            this.fuseFS = fuseFS;
     }
 
     // Inner classes.

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/ConcreteFuseFS.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/ConcreteFuseFS.java
@@ -268,6 +268,12 @@ public class ConcreteFuseFS extends FuseStubFS {
 
     @Override
     public Pointer init(Pointer conn) {
+        fuseLockManager.init(this);
+        fileManager.init(this);
+        directoryManager.init(this);
+        linkManager.init(this);
+        fsActionManager.init(this);
+
         return conn;
     }
 

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseDirectoryManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseDirectoryManager.java
@@ -4,7 +4,7 @@ import jnr.ffi.Pointer;
 import ru.serce.jnrfuse.FuseFillDir;
 import ru.serce.jnrfuse.struct.FuseFileInfo;
 
-public interface FuseDirectoryManager {
+public interface FuseDirectoryManager extends FuseManager {
 
     int mkdir(String path, long mode);
 

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseFSActionManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseFSActionManager.java
@@ -3,7 +3,7 @@ package org.bandrsoftwares.cipherbox.fuse;
 import ru.serce.jnrfuse.struct.FileStat;
 import ru.serce.jnrfuse.struct.Statvfs;
 
-public interface FuseFSActionManager {
+public interface FuseFSActionManager extends FuseManager {
 
     int statfs(String path, Statvfs stbuf);
 

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseFileManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseFileManager.java
@@ -4,7 +4,7 @@ import jnr.ffi.Pointer;
 import ru.serce.jnrfuse.struct.FuseFileInfo;
 import ru.serce.jnrfuse.struct.Timespec;
 
-public interface FuseFileManager {
+public interface FuseFileManager extends FuseManager {
 
     int create(String path, long mode, FuseFileInfo fi);
 

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseLinkManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseLinkManager.java
@@ -2,7 +2,7 @@ package org.bandrsoftwares.cipherbox.fuse;
 
 import jnr.ffi.Pointer;
 
-public interface FuseLinkManager {
+public interface FuseLinkManager extends FuseManager{
 
     int symlink(String targetPath, String linkPath);
 

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseLockManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseLockManager.java
@@ -2,7 +2,7 @@ package org.bandrsoftwares.cipherbox.fuse;
 
 import java.nio.file.Path;
 
-public interface FuseLockManager {
+public interface FuseLockManager extends FuseManager {
 
     PathLock getLock(Path path);
 }

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/FuseManager.java
@@ -1,0 +1,14 @@
+package org.bandrsoftwares.cipherbox.fuse;
+
+import lombok.NonNull;
+
+public interface FuseManager {
+
+    ConcreteFuseFS getFuseFS();
+
+    void init(@NonNull ConcreteFuseFS fuseFS);
+
+    default boolean hasBeenInitialized() {
+        return getFuseFS() != null;
+    }
+}

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/BasicFileReference.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/BasicFileReference.java
@@ -52,8 +52,9 @@ public class BasicFileReference implements FileReference {
 
     @Override
     public int read(Pointer buf, long size, long offset) throws IOException {
-        if (offset >= size) {
-            log.warn("Try to read over file size");
+        long fcSize = fileChannel.size();
+        if (offset >= fcSize) {
+            log.warn("Try to read over file size, Current file channel size {}, offset {}, size {}", fcSize, offset, size);
             return 0;
         }
 
@@ -65,10 +66,10 @@ public class BasicFileReference implements FileReference {
             long remaining = size - pos;
             int read = readNext(buffer, remaining);
 
-            if (read != -1) {
-                // Impossible case
-                log.error("Read until EOF -> IMPOSSIBLE CASE");
-                return (int) pos;
+            if (read == -1) {
+                buf.put(pos, buffer.array(), 0, buffer.position());
+                pos += buffer.position();
+                break; // Very important
             } else {
                 buf.put(pos, buffer.array(), 0, read);
                 pos += read;

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/BasicFileReferenceGenerator.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/BasicFileReferenceGenerator.java
@@ -40,6 +40,6 @@ public class BasicFileReferenceGenerator implements FileReferenceGenerator {
     @Documented
     @Qualifier
     @Retention(RetentionPolicy.RUNTIME)
-    @interface BufferSize {
+    public @interface BufferSize {
     }
 }

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/NIOFuseManager.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/NIOFuseManager.java
@@ -4,14 +4,27 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.bandrsoftwares.cipherbox.fuse.ConcreteFuseFS;
+import org.bandrsoftwares.cipherbox.fuse.FuseManager;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public abstract class NIOFuseManager {
+public abstract class NIOFuseManager implements FuseManager {
 
     // Variables.
 
     @NonNull
     private final PhysicalPathRecover pathRecover;
 
+    /**
+     * Must be initialized.
+     */
+    private ConcreteFuseFS fuseFS;
+
+    // Methods.
+
+    @Override
+    public void init(@NonNull ConcreteFuseFS fuseFS) {
+        if (!hasBeenInitialized()) this.fuseFS = fuseFS;
+    }
 }

--- a/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/OneDirectoryLinkPathRecover.java
+++ b/src/main/java/org/bandrsoftwares/cipherbox/fuse/nio/OneDirectoryLinkPathRecover.java
@@ -1,7 +1,9 @@
 package org.bandrsoftwares.cipherbox.fuse.nio;
 
+import com.google.common.base.CharMatcher;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.inject.Inject;
 import javax.inject.Qualifier;
@@ -10,6 +12,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Implementation of {@link PhysicalPathRecover} which is link to only ONE physical directory. This directory will be the root of the File System and
@@ -17,6 +20,7 @@ import java.nio.file.Path;
  * <p>
  * The method {@link #recover(Path)} only call {@link Path#resolve(Path)} to create the physical path of a fuse path.
  */
+@Slf4j
 @Getter
 @Singleton
 public class OneDirectoryLinkPathRecover implements PhysicalPathRecover {
@@ -37,6 +41,7 @@ public class OneDirectoryLinkPathRecover implements PhysicalPathRecover {
 
     @Override
     public Path recover(@NonNull Path fusePath) {
+        fusePath = Paths.get(CharMatcher.anyOf("/\\").trimLeadingFrom(fusePath.toString()));
         return rootDirectory.resolve(fusePath);
     }
 
@@ -45,6 +50,6 @@ public class OneDirectoryLinkPathRecover implements PhysicalPathRecover {
     @Documented
     @Qualifier
     @Retention(RetentionPolicy.RUNTIME)
-    @interface RootDirectory {
+    public @interface RootDirectory {
     }
 }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="debug">
+        <Root level="trace">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
# Add Example

Create "example" package which contains
GuiceModule and Main class to run an
example with NIO Fuse.

# Bug fixing


## Fix get attr bug

Get attr do not correctly set access to
file on Windows (not tested on linux).

Access has been review and now write
actions can be done and work correctly

## Fix read bug

BasicFileReference has a bug.
When EOF was reach, the file channel
returns -1. We use comparaison to know
if the EOF was reach however the condition
was wrong, instead of read == -1, it was
wrote read != -1.

In addition, if the EOF has been reach,
put in the buf pointer the rest of the
buffer which has been read.

Bug has been fixed

## Fix bug of OneDirectoryLinkPathRecover

FusePath begin with "/" or "\" and this make
that the method Path.resolve() returns a
not correct value.
To fix that, remove the first character "/"
or "\" of the fusePath given in the
OneDirectoryLinkPathRecover.recover() method