### PR TITLE
#18 Change the way to get File attribute

### DIFF
--- a/core/src/main/java/org/callimard/easyfuse/core/ConcreteFuseFS.java
+++ b/core/src/main/java/org/callimard/easyfuse/core/ConcreteFuseFS.java
@@ -34,6 +34,9 @@ public class ConcreteFuseFS extends FuseStubFS {
     private final FuseLinkManager linkManager;
 
     @NonNull
+    private final FuseAttributeGetterManager fuseAttributeGetterManager;
+
+    @NonNull
     private final FuseFSActionManager fsActionManager;
 
     // Constructors.
@@ -41,11 +44,12 @@ public class ConcreteFuseFS extends FuseStubFS {
     @Inject
     public ConcreteFuseFS(@NonNull FuseLockManager fuseLockManager, @NonNull FuseFileManager fileManager,
                           @NonNull FuseDirectoryManager directoryManager, @NonNull FuseLinkManager linkManager,
-                          @NonNull FuseFSActionManager fsActionManager) {
+                          @NonNull FuseAttributeGetterManager fuseAttributeGetterManager, @NonNull FuseFSActionManager fsActionManager) {
         this.fuseLockManager = fuseLockManager;
         this.fileManager = fileManager;
         this.directoryManager = directoryManager;
         this.linkManager = linkManager;
+        this.fuseAttributeGetterManager = fuseAttributeGetterManager;
         this.fsActionManager = fsActionManager;
     }
 
@@ -217,7 +221,7 @@ public class ConcreteFuseFS extends FuseStubFS {
     @Override
     public int getattr(String path, FileStat stat) {
         try (CloseableLock ignored = fuseLockManager.getLock(Paths.get(path)).lockToRead()) {
-            return fsActionManager.getattr(path, stat);
+            return fuseAttributeGetterManager.getAttribute(path, stat);
         } catch (RuntimeException e) {
             log.error("Fail to get attributes for " + path, e);
             return -ErrorCodes.EIO();
@@ -274,6 +278,7 @@ public class ConcreteFuseFS extends FuseStubFS {
         directoryManager.init(this);
         linkManager.init(this);
         fsActionManager.init(this);
+        fuseAttributeGetterManager.init(this);
 
         return conn;
     }

--- a/core/src/main/java/org/callimard/easyfuse/core/FuseAttributeGetterManager.java
+++ b/core/src/main/java/org/callimard/easyfuse/core/FuseAttributeGetterManager.java
@@ -1,0 +1,8 @@
+package org.callimard.easyfuse.core;
+
+import ru.serce.jnrfuse.struct.FileStat;
+
+public interface FuseAttributeGetterManager extends FuseManager {
+
+    int getAttribute(String path, FileStat stat);
+}

--- a/core/src/main/java/org/callimard/easyfuse/core/FuseFSActionManager.java
+++ b/core/src/main/java/org/callimard/easyfuse/core/FuseFSActionManager.java
@@ -1,6 +1,5 @@
 package org.callimard.easyfuse.core;
 
-import ru.serce.jnrfuse.struct.FileStat;
 import ru.serce.jnrfuse.struct.Statvfs;
 
 public interface FuseFSActionManager extends FuseManager {
@@ -8,8 +7,6 @@ public interface FuseFSActionManager extends FuseManager {
     int statfs(String path, Statvfs stbuf);
 
     int access(String path, int mask);
-
-    int getattr(String path, FileStat stat);
 
     int rename(String oldPath, String newPath);
 

--- a/nio/src/main/java/org/callimard/easyfuse/nio/BasicAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/BasicAttributeGetter.java
@@ -1,0 +1,16 @@
+package org.callimard.easyfuse.nio;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BasicAttributeGetter {
+
+    // Variables.
+
+    @NonNull
+    private final FileAttributesUtil fileAttributesUtil;
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/BasicDirectoryAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/BasicDirectoryAttributeGetter.java
@@ -1,0 +1,34 @@
+package org.callimard.easyfuse.nio;
+
+import lombok.NonNull;
+import org.callimard.easyfuse.core.ConcreteFuseFS;
+import ru.serce.jnrfuse.struct.FileStat;
+
+import javax.inject.Inject;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributes;
+
+public class BasicDirectoryAttributeGetter extends BasicAttributeGetter implements NIODirectoryAttributeGetter {
+
+    // Constructors.
+
+    @Inject
+    public BasicDirectoryAttributeGetter(@NonNull FileAttributesUtil fileAttributesUtil) {
+        super(fileAttributesUtil);
+    }
+
+    // Methods.
+
+    @Override
+    public int getAttribute(BasicFileAttributes attributes, FileStat stat, ConcreteFuseFS fuseFS) {
+        if (attributes instanceof PosixFileAttributes posixAttr) {
+            long mode = getFileAttributesUtil().posixPermissionsToOctalMode(posixAttr.permissions());
+            mode = mode & 0555;
+            stat.st_mode.set(FileStat.S_IFDIR | mode);
+        } else {
+            stat.st_mode.set(FileStat.S_IFDIR | 0777);
+        }
+        getFileAttributesUtil().copyBasicFileAttributesFromNioToFuse(attributes, stat, fuseFS);
+        return 0;
+    }
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/BasicFileAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/BasicFileAttributeGetter.java
@@ -1,0 +1,36 @@
+package org.callimard.easyfuse.nio;
+
+import lombok.NonNull;
+import org.callimard.easyfuse.core.ConcreteFuseFS;
+import ru.serce.jnrfuse.struct.FileStat;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributes;
+
+@Singleton
+public class BasicFileAttributeGetter extends BasicAttributeGetter implements NIOFileAttributeGetter {
+
+    // Constructors.
+
+    @Inject
+    public BasicFileAttributeGetter(@NonNull FileAttributesUtil fileAttributesUtil) {
+        super(fileAttributesUtil);
+    }
+
+    // Methods.
+
+    @Override
+    public int getAttribute(BasicFileAttributes attributes, FileStat stat, ConcreteFuseFS fuseFS) {
+        if (attributes instanceof PosixFileAttributes posixAttr) {
+            long mode = getFileAttributesUtil().posixPermissionsToOctalMode(posixAttr.permissions());
+            mode = mode & 0555;
+            stat.st_mode.set(FileStat.S_IFREG | mode);
+        } else {
+            stat.st_mode.set(FileStat.S_IFREG | 0777);
+        }
+        getFileAttributesUtil().copyBasicFileAttributesFromNioToFuse(attributes, stat, fuseFS);
+        return 0;
+    }
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/BasicLinkAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/BasicLinkAttributeGetter.java
@@ -1,0 +1,34 @@
+package org.callimard.easyfuse.nio;
+
+import lombok.NonNull;
+import org.callimard.easyfuse.core.ConcreteFuseFS;
+import ru.serce.jnrfuse.struct.FileStat;
+
+import javax.inject.Inject;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributes;
+
+public class BasicLinkAttributeGetter extends BasicAttributeGetter implements NIOLinkAttributeGetter {
+
+    // Constructors.
+
+    @Inject
+    public BasicLinkAttributeGetter(@NonNull FileAttributesUtil fileAttributesUtil) {
+        super(fileAttributesUtil);
+    }
+
+    // Methods.
+
+    @Override
+    public int getAttribute(BasicFileAttributes attributes, FileStat stat, ConcreteFuseFS fuseFS) {
+        if (attributes instanceof PosixFileAttributes posixAttr) {
+            long mode = getFileAttributesUtil().posixPermissionsToOctalMode(posixAttr.permissions());
+            mode = mode & 0555;
+            stat.st_mode.set(FileStat.S_IFLNK | mode);
+        } else {
+            stat.st_mode.set(FileStat.S_IFLNK | 0777);
+        }
+        getFileAttributesUtil().copyBasicFileAttributesFromNioToFuse(attributes, stat, fuseFS);
+        return 0;
+    }
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/FileAttributesUtil.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/FileAttributesUtil.java
@@ -1,11 +1,14 @@
 package org.callimard.easyfuse.nio;
 
+import jnr.posix.util.Platform;
+import org.callimard.easyfuse.core.ConcreteFuseFS;
 import ru.serce.jnrfuse.flags.AccessConstants;
 import ru.serce.jnrfuse.struct.FileStat;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.nio.file.AccessMode;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.EnumSet;
 import java.util.Set;
@@ -58,6 +61,39 @@ public class FileAttributesUtil {
         if (permissions.contains(PosixFilePermission.OTHERS_EXECUTE)) mode = mode | FileStat.S_IXOTH;
         // @formatter:on
         return mode;
+    }
+
+    public void copyBasicFileAttributesFromNioToFuse(BasicFileAttributes attrs, FileStat stat, ConcreteFuseFS fuseFS) {
+        if (attrs.isDirectory()) {
+            stat.st_mode.set(stat.st_mode.longValue() | FileStat.S_IFDIR);
+        } else if (attrs.isRegularFile()) {
+            stat.st_mode.set(stat.st_mode.longValue() | FileStat.S_IFREG);
+        } else if (attrs.isSymbolicLink()) {
+            stat.st_mode.set(stat.st_mode.longValue() | FileStat.S_IFLNK);
+        }
+        stat.st_uid.set(fuseFS.getContext().uid.get());
+        stat.st_gid.set(fuseFS.getContext().gid.get());
+
+        stat.st_mtim.tv_sec.set(attrs.lastModifiedTime().toInstant().getEpochSecond());
+        stat.st_mtim.tv_nsec.set(attrs.lastModifiedTime().toInstant().getNano());
+        stat.st_ctim.tv_sec.set(attrs.creationTime().toInstant().getEpochSecond());
+        stat.st_ctim.tv_nsec.set(attrs.creationTime().toInstant().getNano());
+
+        if (Platform.IS_MAC || Platform.IS_WINDOWS) {
+            stat.st_birthtime.tv_sec.set(attrs.creationTime().toInstant().getEpochSecond());
+            stat.st_birthtime.tv_nsec.set(attrs.creationTime().toInstant().getNano());
+        }
+
+        stat.st_atim.tv_sec.set(attrs.lastAccessTime().toInstant().getEpochSecond());
+        stat.st_atim.tv_nsec.set(attrs.lastAccessTime().toInstant().getNano());
+        stat.st_size.set(attrs.size());
+        stat.st_nlink.set(1);
+        // make sure to nil certain fields known to contain garbage from uninitialized memory
+        // fixes alleged permission bugs, see https://github.com/cryptomator/fuse-nio-adapter/issues/19
+        if (Platform.IS_MAC) {
+            stat.st_flags.set(0);
+            stat.st_gen.set(0);
+        }
     }
 
 }

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOAttributeGetter.java
@@ -1,0 +1,11 @@
+package org.callimard.easyfuse.nio;
+
+import org.callimard.easyfuse.core.ConcreteFuseFS;
+import ru.serce.jnrfuse.struct.FileStat;
+
+import java.nio.file.attribute.BasicFileAttributes;
+
+public interface NIOAttributeGetter {
+
+    int getAttribute(BasicFileAttributes attributes, FileStat stat, ConcreteFuseFS fuseFS);
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIODirectoryAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIODirectoryAttributeGetter.java
@@ -1,0 +1,4 @@
+package org.callimard.easyfuse.nio;
+
+public interface NIODirectoryAttributeGetter extends NIOAttributeGetter {
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOEntryPointFuseAttributeGetterManager.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOEntryPointFuseAttributeGetterManager.java
@@ -1,0 +1,52 @@
+package org.callimard.easyfuse.nio;
+
+import jnr.posix.util.Platform;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import ru.serce.jnrfuse.struct.FileStat;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Slf4j
+@Singleton
+public class NIOEntryPointFuseAttributeGetterManager extends NIOFuseAttributeGetterManager {
+
+    // Constructors.
+
+    @Inject
+    public NIOEntryPointFuseAttributeGetterManager(@NonNull PhysicalPathRecover pathRecover, @NonNull NIOFileAttributeGetter fileAttributeGetter,
+                                                   @NonNull NIODirectoryAttributeGetter directoryAttributeGetter,
+                                                   @NonNull NIOLinkAttributeGetter linkAttributeGetter) {
+        super(pathRecover, fileAttributeGetter, directoryAttributeGetter, linkAttributeGetter);
+    }
+
+    // Methods.
+
+    @Override
+    public int getAttribute(String path, FileStat stat) {
+        var fusePath = Paths.get(path);
+        if (isFuseRootPath(fusePath)) {
+            log.trace("Get attr of fuse root path {}", path);
+            stat.st_mode.set(FileStat.S_IFDIR | 0777);
+            stat.st_uid.set(getFuseFS().getContext().uid.get());
+            stat.st_gid.set(getFuseFS().getContext().gid.get());
+
+            stat.st_nlink.set(1);
+            if (Platform.IS_MAC) {
+                stat.st_flags.set(0);
+                stat.st_gen.set(0);
+            }
+
+            return 0;
+        } else {
+            return super.getAttribute(path, stat);
+        }
+    }
+
+    private boolean isFuseRootPath(Path path) {
+        return path.getNameCount() == 0;
+    }
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOEntryPointFuseFSActionManager.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOEntryPointFuseFSActionManager.java
@@ -1,10 +1,8 @@
 package org.callimard.easyfuse.nio;
 
-import jnr.posix.util.Platform;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import ru.serce.jnrfuse.ErrorCodes;
-import ru.serce.jnrfuse.struct.FileStat;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -32,27 +30,6 @@ public class NIOEntryPointFuseFSActionManager extends NIOFuseFSActionManager {
             return -ErrorCodes.EACCES();
         } else {
             return super.chown(path, uid, gid);
-        }
-    }
-
-    @Override
-    public int getattr(String path, FileStat stat) {
-        var fusePath = Paths.get(path);
-        if (isFuseRootPath(fusePath)) {
-            log.trace("Get attr of fuse root path {}", path);
-            stat.st_mode.set(FileStat.S_IFDIR | 0777);
-            stat.st_uid.set(getFuseFS().getContext().uid.get());
-            stat.st_gid.set(getFuseFS().getContext().gid.get());
-
-            stat.st_nlink.set(1);
-            if (Platform.IS_MAC) {
-                stat.st_flags.set(0);
-                stat.st_gen.set(0);
-            }
-
-            return 0;
-        } else {
-            return super.getattr(path, stat);
         }
     }
 
@@ -87,10 +64,6 @@ public class NIOEntryPointFuseFSActionManager extends NIOFuseFSActionManager {
         } else {
             return super.chmod(path, mode);
         }
-    }
-
-    private boolean isFuseRootPath(Path path) {
-        return path.getNameCount() == 0;
     }
 
     private boolean isEntryPointRoot(Path path) {

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOFileAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOFileAttributeGetter.java
@@ -1,0 +1,4 @@
+package org.callimard.easyfuse.nio;
+
+public interface NIOFileAttributeGetter extends NIOAttributeGetter {
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOFuseAttributeGetterManager.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOFuseAttributeGetterManager.java
@@ -1,0 +1,80 @@
+package org.callimard.easyfuse.nio;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.callimard.easyfuse.core.FuseAttributeGetterManager;
+import ru.serce.jnrfuse.ErrorCodes;
+import ru.serce.jnrfuse.struct.FileStat;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFileAttributes;
+
+@Slf4j
+@Singleton
+public class NIOFuseAttributeGetterManager extends NIOFuseManager implements FuseAttributeGetterManager {
+
+    // Variables.
+
+    @NonNull
+    private final NIOFileAttributeGetter fileAttributeGetter;
+
+    @NonNull
+    private final NIODirectoryAttributeGetter directoryAttributeGetter;
+
+    @NonNull
+    private final NIOLinkAttributeGetter linkAttributeGetter;
+
+    // Constructors.
+
+    @Inject
+    public NIOFuseAttributeGetterManager(@NonNull PhysicalPathRecover pathRecover, @NonNull NIOFileAttributeGetter fileAttributeGetter,
+                                         @NonNull NIODirectoryAttributeGetter directoryAttributeGetter,
+                                         @NonNull NIOLinkAttributeGetter linkAttributeGetter) {
+        super(pathRecover);
+        this.fileAttributeGetter = fileAttributeGetter;
+        this.directoryAttributeGetter = directoryAttributeGetter;
+        this.linkAttributeGetter = linkAttributeGetter;
+    }
+
+
+    // Methods.
+
+    @Override
+    public int getAttribute(String path, FileStat stat) {
+        Path physicalPath = getPathRecover().recover(Paths.get(path));
+        try {
+            log.trace("Get attr for {}", path);
+
+            FileStore fileStore = Files.getFileStore(physicalPath);
+
+            BasicFileAttributes attrs;
+            if (fileStore.supportsFileAttributeView(PosixFileAttributeView.class)) {
+                attrs = Files.readAttributes(physicalPath, PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            } else {
+                attrs = Files.readAttributes(physicalPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            }
+
+            if (attrs.isRegularFile()) {
+                return fileAttributeGetter.getAttribute(attrs, stat, getFuseFS());
+            } else if (attrs.isDirectory()) {
+                return directoryAttributeGetter.getAttribute(attrs, stat, getFuseFS());
+            } else if (attrs.isSymbolicLink()) {
+                return linkAttributeGetter.getAttribute(attrs, stat, getFuseFS());
+            } else {
+                log.warn("Fail to get attr of {} because file type is not supported", physicalPath);
+                return -ErrorCodes.ENOTSUP();
+            }
+        } catch (NoSuchFileException e) {
+            log.warn("Fail to get attr of file " + physicalPath + " because it does not exist", e);
+            return -ErrorCodes.ENOENT();
+        } catch (IOException e) {
+            log.error("IO error during get attr of " + physicalPath, e);
+            return -ErrorCodes.EIO();
+        }
+    }
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOFuseFSActionManager.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOFuseFSActionManager.java
@@ -1,21 +1,16 @@
 package org.callimard.easyfuse.nio;
 
 import com.google.common.collect.Iterables;
-import jnr.posix.util.Platform;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.callimard.easyfuse.core.FuseFSActionManager;
 import ru.serce.jnrfuse.ErrorCodes;
-import ru.serce.jnrfuse.struct.FileStat;
 import ru.serce.jnrfuse.struct.Statvfs;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.nio.file.*;
-import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.PosixFileAttributeView;
-import java.nio.file.attribute.PosixFileAttributes;
 import java.util.Set;
 
 @Slf4j
@@ -68,109 +63,6 @@ public class NIOFuseFSActionManager extends NIOFuseManager implements FuseFSActi
         } catch (IOException e) {
             log.error("IO error during check access for " + physicalPath + " with mask " + mask, e);
             return -ErrorCodes.EIO();
-        }
-    }
-
-    @Override
-    public int getattr(String path, FileStat stat) {
-        Path physicalPath = getPathRecover().recover(Paths.get(path));
-        try {
-            log.trace("Get attr for {}", path);
-
-            FileStore fileStore = Files.getFileStore(physicalPath);
-
-            BasicFileAttributes attrs;
-            if (fileStore.supportsFileAttributeView(PosixFileAttributeView.class)) {
-                attrs = Files.readAttributes(physicalPath, PosixFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            } else {
-                attrs = Files.readAttributes(physicalPath, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
-            }
-
-            if (attrs.isRegularFile()) {
-                return getFileAttr(attrs, stat);
-            } else if (attrs.isDirectory()) {
-                return getDirectoryAttr(attrs, stat);
-            } else if (attrs.isSymbolicLink()) {
-                return getSymbolicLinkAttr(attrs, stat);
-            } else {
-                log.warn("Fail to get attr of {} because file type is not supported", physicalPath);
-                return -ErrorCodes.ENOTSUP();
-            }
-        } catch (NoSuchFileException e) {
-            log.warn("Fail to get attr of file " + physicalPath + " because it does not exist", e);
-            return -ErrorCodes.ENOENT();
-        } catch (IOException e) {
-            log.error("IO error during get attr of " + physicalPath, e);
-            return -ErrorCodes.EIO();
-        }
-    }
-
-    private int getFileAttr(BasicFileAttributes attributes, FileStat fileStat) {
-        if (attributes instanceof PosixFileAttributes posixAttr) {
-            long mode = fileAttributesUtil.posixPermissionsToOctalMode(posixAttr.permissions());
-            mode = mode & 0555;
-            fileStat.st_mode.set(FileStat.S_IFREG | mode);
-        } else {
-            fileStat.st_mode.set(FileStat.S_IFREG | 0777);
-        }
-        copyBasicFileAttributesFromNioToFuse(attributes, fileStat);
-        return 0;
-    }
-
-    private int getDirectoryAttr(BasicFileAttributes attributes, FileStat fileStat) {
-        if (attributes instanceof PosixFileAttributes posixAttr) {
-            long mode = fileAttributesUtil.posixPermissionsToOctalMode(posixAttr.permissions());
-            mode = mode & 0555;
-            fileStat.st_mode.set(FileStat.S_IFDIR | mode);
-        } else {
-            fileStat.st_mode.set(FileStat.S_IFDIR | 0777);
-        }
-        copyBasicFileAttributesFromNioToFuse(attributes, fileStat);
-        return 0;
-    }
-
-    private int getSymbolicLinkAttr(BasicFileAttributes attributes, FileStat fileStat) {
-        if (attributes instanceof PosixFileAttributes posixAttr) {
-            long mode = fileAttributesUtil.posixPermissionsToOctalMode(posixAttr.permissions());
-            mode = mode & 0555;
-            fileStat.st_mode.set(FileStat.S_IFLNK | mode);
-        } else {
-            fileStat.st_mode.set(FileStat.S_IFLNK | 0777);
-        }
-        copyBasicFileAttributesFromNioToFuse(attributes, fileStat);
-        return 0;
-    }
-
-    protected void copyBasicFileAttributesFromNioToFuse(BasicFileAttributes attrs, FileStat stat) {
-        if (attrs.isDirectory()) {
-            stat.st_mode.set(stat.st_mode.longValue() | FileStat.S_IFDIR);
-        } else if (attrs.isRegularFile()) {
-            stat.st_mode.set(stat.st_mode.longValue() | FileStat.S_IFREG);
-        } else if (attrs.isSymbolicLink()) {
-            stat.st_mode.set(stat.st_mode.longValue() | FileStat.S_IFLNK);
-        }
-        stat.st_uid.set(getFuseFS().getContext().uid.get());
-        stat.st_gid.set(getFuseFS().getContext().gid.get());
-
-        stat.st_mtim.tv_sec.set(attrs.lastModifiedTime().toInstant().getEpochSecond());
-        stat.st_mtim.tv_nsec.set(attrs.lastModifiedTime().toInstant().getNano());
-        stat.st_ctim.tv_sec.set(attrs.creationTime().toInstant().getEpochSecond());
-        stat.st_ctim.tv_nsec.set(attrs.creationTime().toInstant().getNano());
-
-        if (Platform.IS_MAC || Platform.IS_WINDOWS) {
-            stat.st_birthtime.tv_sec.set(attrs.creationTime().toInstant().getEpochSecond());
-            stat.st_birthtime.tv_nsec.set(attrs.creationTime().toInstant().getNano());
-        }
-
-        stat.st_atim.tv_sec.set(attrs.lastAccessTime().toInstant().getEpochSecond());
-        stat.st_atim.tv_nsec.set(attrs.lastAccessTime().toInstant().getNano());
-        stat.st_size.set(attrs.size());
-        stat.st_nlink.set(1);
-        // make sure to nil certain fields known to contain garbage from uninitialized memory
-        // fixes alleged permission bugs, see https://github.com/cryptomator/fuse-nio-adapter/issues/19
-        if (Platform.IS_MAC) {
-            stat.st_flags.set(0);
-            stat.st_gen.set(0);
         }
     }
 

--- a/nio/src/main/java/org/callimard/easyfuse/nio/NIOLinkAttributeGetter.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/NIOLinkAttributeGetter.java
@@ -1,0 +1,4 @@
+package org.callimard.easyfuse.nio;
+
+public interface NIOLinkAttributeGetter extends NIOAttributeGetter {
+}

--- a/nio/src/main/java/org/callimard/easyfuse/nio/example/NIOOneEntryPointGuiceModule.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/example/NIOOneEntryPointGuiceModule.java
@@ -31,6 +31,11 @@ public class NIOOneEntryPointGuiceModule extends AbstractModule {
 
         bind(FuseLinkManager.class).to(NIOFuseLinkManager.class);
 
+        bind(NIOFileAttributeGetter.class).to(BasicFileAttributeGetter.class);
+        bind(NIODirectoryAttributeGetter.class).to(BasicDirectoryAttributeGetter.class);
+        bind(NIOLinkAttributeGetter.class).to(BasicLinkAttributeGetter.class);
+        bind(FuseAttributeGetterManager.class).to(NIOFuseAttributeGetterManager.class);
+
         bind(FuseFSActionManager.class).to(NIOFuseFSActionManager.class);
     }
 

--- a/nio/src/main/java/org/callimard/easyfuse/nio/example/NIOSeveralEntryPointGuiceModule.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/example/NIOSeveralEntryPointGuiceModule.java
@@ -34,6 +34,11 @@ public class NIOSeveralEntryPointGuiceModule extends AbstractModule {
 
         bind(FuseLinkManager.class).to(NIOFuseLinkManager.class);
 
+        bind(NIOFileAttributeGetter.class).to(BasicFileAttributeGetter.class);
+        bind(NIODirectoryAttributeGetter.class).to(BasicDirectoryAttributeGetter.class);
+        bind(NIOLinkAttributeGetter.class).to(BasicLinkAttributeGetter.class);
+        bind(FuseAttributeGetterManager.class).to(NIOEntryPointFuseAttributeGetterManager.class);
+
         bind(FuseFSActionManager.class).to(NIOEntryPointFuseFSActionManager.class);
     }
 


### PR DESCRIPTION
1. Create FuseAttributeGetterManager

FuseAttributeGetterManager is a FuseManager here to manage how to get attribute of File.

Create NIOFuseAttributeGetterManager which is an
implementation of FuseAttributeGetterManager and
which can get attribute of three type of files:
- file
- directory
- symbolic link

Each of this type has a dedicated NIOAttributeGetter: BasicFileAttributeGetter, BasicDirectoryAttributeGetter and BasicLinkAttributeGetter.

2. Update NIOSeveralEntryPointGuiceModule to add FuseAttributeGetterManager dependencies

3. Update NIOOneEntryPointGuiceModule to add FuseAttributeGetterManager dependencies