### PR TITLE
Fix read bug in NIOFileReference

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -72,8 +72,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>19</source>
-                    <target>19</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/nio/pom.xml
+++ b/nio/pom.xml
@@ -77,8 +77,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>19</source>
-                    <target>19</target>
+                    <source>16</source>
+                    <target>16</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/nio/src/main/java/org/callimard/easyfuse/nio/example/MultiMountPointNIOGuiceModule.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/example/MultiMountPointNIOGuiceModule.java
@@ -3,20 +3,18 @@ package org.callimard.easyfuse.nio.example;
 import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.util.Providers;
 import org.callimard.easyfuse.core.*;
+import org.callimard.easyfuse.core.lock.PathLockManagerImpl;
 import org.callimard.easyfuse.nio.attribute.AttributeUtil;
-import org.callimard.easyfuse.nio.directory.DirectoryAttributeGetter;
-import org.callimard.easyfuse.nio.directory.DirectoryFileFilter;
-import org.callimard.easyfuse.nio.directory.NIODirectoryAttributeGetter;
-import org.callimard.easyfuse.nio.mountpoint.MountPoint;
-import org.callimard.easyfuse.nio.mountpoint.MountPointFactory;
+import org.callimard.easyfuse.nio.directory.*;
 import org.callimard.easyfuse.nio.file.*;
-import org.callimard.easyfuse.nio.directory.NIODirectoryFileFilter;
-import org.callimard.easyfuse.nio.mountpoint.MountPointFactoryImpl;
 import org.callimard.easyfuse.nio.link.LinkAttributeGetter;
 import org.callimard.easyfuse.nio.link.NIOLinkAttributeGetter;
-import org.callimard.easyfuse.core.lock.PathLockManagerImpl;
 import org.callimard.easyfuse.nio.manager.*;
+import org.callimard.easyfuse.nio.mountpoint.MountPoint;
+import org.callimard.easyfuse.nio.mountpoint.MountPointFactory;
+import org.callimard.easyfuse.nio.mountpoint.MountPointFactoryImpl;
 import org.callimard.easyfuse.nio.pathrecover.MultiMountPointPathRecover;
 import org.callimard.easyfuse.nio.pathrecover.PhysicalPathRecover;
 
@@ -56,6 +54,8 @@ public class MultiMountPointNIOGuiceModule extends AbstractModule {
         bind(TruncateManager.class).to(NIOTruncateManager.class);
 
         bind(UtimensManager.class).to(NIOUtimensManager.class);
+
+        bind(FileNameTransformer.class).toProvider(Providers.of(null));
 
         bind(GlobalActionManager.class).to(MultiMountPointNIOGlobalActionManager.class);
     }

--- a/nio/src/main/java/org/callimard/easyfuse/nio/file/NIOFileReference.java
+++ b/nio/src/main/java/org/callimard/easyfuse/nio/file/NIOFileReference.java
@@ -53,10 +53,8 @@ public class NIOFileReference implements FileReference {
     @Override
     public int read(Pointer buf, long size, long offset) throws IOException {
         long fcSize = fileChannel.size();
-        if (offset >= fcSize) {
-            log.warn("Try to read over file size, Current file channel size {}, offset {}, size {}", fcSize, offset, size);
-            return 0;
-        }
+
+        size = Math.min(fcSize - offset, size);
 
         ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
 
@@ -67,6 +65,7 @@ public class NIOFileReference implements FileReference {
             int read = readNext(buffer, remaining);
 
             if (read == -1) {
+                log.warn("Reach EOF -> MUST NEVER HAPPEN");
                 buf.put(pos, buffer.array(), 0, buffer.position());
                 pos += buffer.position();
                 break; // Very important


### PR DESCRIPTION
Sometimes the read reach EOF which must not
be possible. To avoid this, re-evaluate the
number of byte to read by choosing the min
between the given size to read and the current
fiche channel size minus the given file offset